### PR TITLE
Add incremental editing helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -662,6 +662,7 @@ RIFT development maintains alignment with NASA-STD-8739.8 software safety assura
 - **Documentation**: Comprehensive technical specifications in `/docs/`
 - **Issue Tracking**: GitHub Issues with systematic problem reporting templates
 - **QA Framework**: Automated validation through `./tools/qa_framework.sh`
+- **Incremental Edit Helper**: `./scripts/rift_incremental_edit.sh`
 
 **Development Coordination:**
 - **Technical Leadership**: Systematic problem identification with collaborative resolution

--- a/docs/incremental_edit_loop.md
+++ b/docs/incremental_edit_loop.md
@@ -1,0 +1,9 @@
+# Incremental Edit Loop
+
+`scripts/rift_incremental_edit.sh` automates document updates across RIFT stages.
+
+1. The script searches for the highest `rift-N` directory and creates an alias `rift-exe` for the corresponding executable.
+2. Each time you provide an edit prompt, it copies `current.riftrc.N.in` to `current.riftrc.(N+1).in`, applies the edit via `apply_edit`, and runs `rift-(N+1).exe`.
+3. After a successful run the alias is updated so further edits operate on the new stage.
+
+This lightweight helper demonstrates how RIFT artifacts can drive incremental documentation updates.

--- a/scripts/rift_incremental_edit.sh
+++ b/scripts/rift_incremental_edit.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# RIFT Incremental Edit Helper - Manage document sections via stage artifacts
+
+set -euo pipefail
+
+# Discover latest stage directory like rift-0, rift-1, ...
+latest=$(ls -d rift-[0-9]* 2>/dev/null | sed -E 's/.*rift-([0-9]+)$/\1/' | sort -n | tail -1)
+if [[ -z "$latest" ]]; then
+    echo "No RIFT stage directories found" >&2
+    exit 1
+fi
+
+alias rift-exe="rift-${latest}.exe"
+echo "Using stage rift-${latest}"
+
+while true; do
+    read -rp "Edit prompt: " edit_input || break
+    next=$((latest + 1))
+    cp "current.riftrc.${latest}.in" "current.riftrc.${next}.in" 2>/dev/null || true
+    # apply_edit is a user-provided function that edits the input file
+    apply_edit "current.riftrc.${next}.in" "$edit_input"
+    "rift-${next}.exe" "current.riftrc.${next}.in" -o build
+    latest=$next
+    alias rift-exe="rift-${latest}.exe"
+    echo "Bumped to stage rift-${latest}"
+done


### PR DESCRIPTION
## Summary
- document incremental edit loop
- add helper script `scripts/rift_incremental_edit.sh`
- reference new script in README

## Testing
- `bash tools/qa_framework.sh --help`
- `bash tools/qa_framework.sh` (fails: missing valgrind)


------
https://chatgpt.com/codex/tasks/task_e_685c74fb29cc8327a2ddb4f8188ea04f