### PR TITLE
Fix rift-0 pkgconfig template path

### DIFF
--- a/rift-0/CMakeLists.txt
+++ b/rift-0/CMakeLists.txt
@@ -29,7 +29,7 @@ if(TARGET rift-0_static)
 endif()
 
 configure_file(
-  ${CMAKE_SOURCE_DIR}/config_templates/rift-0.pc.in
+  ${CMAKE_CURRENT_SOURCE_DIR}/config_templates/rift-0.pc.in
   ${CMAKE_BINARY_DIR}/lib/pkgconfig/rift-0.pc @ONLY
 )
 


### PR DESCRIPTION
## Summary
- fix path for rift-0 pkgconfig template so cmake uses the stage-local config

## Testing
- `cmake ..` *(fails: OBJECT library may not have POST_BUILD command)*
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_685c79e6f7008327aca25303a2afb83e