### PR TITLE
Handle unimplemented CLI commands

### DIFF
--- a/include/rift/core/common.h
+++ b/include/rift/core/common.h
@@ -51,6 +51,7 @@ typedef enum {
     RIFT_ERROR_OUT_OF_BOUNDS = -8,
     RIFT_ERROR_TIMEOUT = -9,
     RIFT_ERROR_INTERRUPTED = -10,
+    RIFT_ERROR_NOT_IMPLEMENTED = -11,
     
     // Tokenizer Error Codes (-100 to -199)
     RIFT_ERROR_TOKEN_BUFFER_OVERFLOW = -100,

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -496,10 +496,37 @@ static void print_performance_summary(const rift_performance_metrics_t* metrics)
 }
 
 // Stub implementations for remaining commands
-static int cmd_parse(void) { RIFT_LOG_INFO("Parse command - implementation pending"); return RIFT_SUCCESS; }
-static int cmd_analyze(void) { RIFT_LOG_INFO("Analyze command - implementation pending"); return RIFT_SUCCESS; }
-static int cmd_validate(void) { RIFT_LOG_INFO("Validate command - implementation pending"); return RIFT_SUCCESS; }
-static int cmd_generate(void) { RIFT_LOG_INFO("Generate command - implementation pending"); return RIFT_SUCCESS; }
-static int cmd_verify(void) { RIFT_LOG_INFO("Verify command - implementation pending"); return RIFT_SUCCESS; }
-static int cmd_emit(void) { RIFT_LOG_INFO("Emit command - implementation pending"); return RIFT_SUCCESS; }
-static int cmd_governance(void) { RIFT_LOG_INFO("Governance command - implementation pending"); return RIFT_SUCCESS; }
+static int cmd_parse(void) {
+    RIFT_LOG_INFO("Parse command not implemented");
+    return RIFT_ERROR_NOT_IMPLEMENTED;
+}
+
+static int cmd_analyze(void) {
+    RIFT_LOG_INFO("Analyze command not implemented");
+    return RIFT_ERROR_NOT_IMPLEMENTED;
+}
+
+static int cmd_validate(void) {
+    RIFT_LOG_INFO("Validate command not implemented");
+    return RIFT_ERROR_NOT_IMPLEMENTED;
+}
+
+static int cmd_generate(void) {
+    RIFT_LOG_INFO("Generate command not implemented");
+    return RIFT_ERROR_NOT_IMPLEMENTED;
+}
+
+static int cmd_verify(void) {
+    RIFT_LOG_INFO("Verify command not implemented");
+    return RIFT_ERROR_NOT_IMPLEMENTED;
+}
+
+static int cmd_emit(void) {
+    RIFT_LOG_INFO("Emit command not implemented");
+    return RIFT_ERROR_NOT_IMPLEMENTED;
+}
+
+static int cmd_governance(void) {
+    RIFT_LOG_INFO("Governance command not implemented");
+    return RIFT_ERROR_NOT_IMPLEMENTED;
+}

--- a/tests/unit/test_cli_commands.c
+++ b/tests/unit/test_cli_commands.c
@@ -1,0 +1,44 @@
+#include "rift/core/common.h"
+#include <stdio.h>
+
+/* Forward declarations of CLI command stubs */
+int cmd_parse(void);
+int cmd_analyze(void);
+int cmd_validate(void);
+int cmd_generate(void);
+int cmd_verify(void);
+int cmd_emit(void);
+int cmd_governance(void);
+
+int main(void) {
+    int failures = 0;
+
+    if (cmd_parse() != RIFT_ERROR_NOT_IMPLEMENTED) {
+        printf("cmd_parse should return RIFT_ERROR_NOT_IMPLEMENTED\n");
+        failures++; }
+    if (cmd_analyze() != RIFT_ERROR_NOT_IMPLEMENTED) {
+        printf("cmd_analyze should return RIFT_ERROR_NOT_IMPLEMENTED\n");
+        failures++; }
+    if (cmd_validate() != RIFT_ERROR_NOT_IMPLEMENTED) {
+        printf("cmd_validate should return RIFT_ERROR_NOT_IMPLEMENTED\n");
+        failures++; }
+    if (cmd_generate() != RIFT_ERROR_NOT_IMPLEMENTED) {
+        printf("cmd_generate should return RIFT_ERROR_NOT_IMPLEMENTED\n");
+        failures++; }
+    if (cmd_verify() != RIFT_ERROR_NOT_IMPLEMENTED) {
+        printf("cmd_verify should return RIFT_ERROR_NOT_IMPLEMENTED\n");
+        failures++; }
+    if (cmd_emit() != RIFT_ERROR_NOT_IMPLEMENTED) {
+        printf("cmd_emit should return RIFT_ERROR_NOT_IMPLEMENTED\n");
+        failures++; }
+    if (cmd_governance() != RIFT_ERROR_NOT_IMPLEMENTED) {
+        printf("cmd_governance should return RIFT_ERROR_NOT_IMPLEMENTED\n");
+        failures++; }
+
+    if (failures == 0) {
+        printf("All CLI command stub tests passed\n");
+        return 0;
+    }
+
+    return 1;
+}


### PR DESCRIPTION
## Summary
- define `RIFT_ERROR_NOT_IMPLEMENTED`
- mark CLI command stubs in `main.c` to return `RIFT_ERROR_NOT_IMPLEMENTED`
- add unit test covering CLI command stubs

## Testing
- `gcc -Iinclude tests/unit/test_cli_commands.c src/cli/main.c -o /tmp/test_cli` *(fails: fatal error: rift/core/stage-2/semantic.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685c8ae786e48327ad3cba46e3814fa2