### PR TITLE
Add policy validation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -547,6 +547,8 @@ stage_transition_result_t validate_stage_transition(int from_stage, int to_stage
 ./tools/dependency_validation.sh --circular-check
 
 # Governance compliance verification
+# The `policy_validation.sh` script checks for all `.riftrc.N` governance files
+# and exits with a non-zero status if any are missing.
 ./rift-gov/policy_validation.sh --stage=all
 ./tools/aegis_recovery.sh --validate-governance
 ```

--- a/rift-gov/policy_validation.sh
+++ b/rift-gov/policy_validation.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Basic policy validation for RIFT governance
+# Checks for required .riftrc.N files
+
+set -euo pipefail
+
+usage() {
+    echo "Usage: $0 --stage=<N|all>" >&2
+    exit 2
+}
+
+dir="$(cd "$(dirname "$0")" && pwd)"
+stage_arg="all"
+
+for arg in "$@"; do
+    case "$arg" in
+        --stage=*) stage_arg="${arg#*=}" ;;
+        -*) usage ;;
+    esac
+    shift || true
+done
+
+check_stage() {
+    local s="$1"
+    local f="$dir/.riftrc.$s"
+    if [[ -f "$f" ]]; then
+        echo "Found $f"
+    else
+        echo "Missing $f" >&2
+        return 1
+    fi
+}
+
+if [[ "$stage_arg" == "all" ]]; then
+    result=0
+    for i in {0..6}; do
+        if ! check_stage "$i"; then
+            result=1
+        fi
+    done
+    exit $result
+elif [[ "$stage_arg" =~ ^[0-6]$ ]]; then
+    check_stage "$stage_arg"
+    exit $?
+else
+    usage
+fi

--- a/scripts/build/build-all.sh
+++ b/scripts/build/build-all.sh
@@ -19,3 +19,17 @@ build_stages_in_order() {
 
 build_stages_in_order
 echo "✅ Build orchestration complete"
+
+echo "🔍 Running policy validation"
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+root_dir="$(cd "$script_dir/../.." && pwd)"
+policy_script="$root_dir/rift-gov/policy_validation.sh"
+if [[ -x "$policy_script" ]]; then
+    "$policy_script" --stage=all || {
+        echo "Policy validation failed" >&2
+        exit 1
+    }
+else
+    echo "Policy validation script not found: $policy_script" >&2
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- implement `rift-gov/policy_validation.sh` to verify `.riftrc.N` files
- call policy validation from build orchestration
- document policy validation usage in README

## Testing
- `bash rift-gov/policy_validation.sh --stage=all`
- `bash scripts/build/build-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_685c8ae6f2108327831968453e9ca292