### PR TITLE
Update governance docs and add validation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,10 +290,13 @@ rift/
 │   ├── wasm/               # WebAssembly compilation targets
 │   ├── repl/               # Interactive development environment
 │   └── bindings/           # Language-specific integration APIs
-├── rift-gov/               # Governance contracts & policy enforcement
-│   ├── .riftrc.0 ... .riftrc.6  # Stage-specific governance files
-│   ├── cost_thresholds.json     # Sinphasé cost configuration
-│   └── policy_validation.sh     # Automated compliance verification
+├── rift-gov/               # Governance utilities & docs
+│   ├── accessibility_error_header.txt  # Error handling header notes
+│   ├── accessibility_error_system.txt  # Error handling implementation
+│   ├── cmake_utility_modules.txt       # CMake module list
+│   ├── rift-dir-to-fix-clutterd.txt    # Directory cleanup plan
+│   ├── rift_consolidated_setup.sh      # Infrastructure setup helper
+│   └── policy_validation.sh            # Compliance automation
 └── rift-telemetry/         # Cryptographic tracking & monitoring
     ├── prng_generators/    # Secure random number generation
     ├── uuid_tracking/      # Unique identifier management
@@ -464,9 +467,12 @@ rift/
 │   ├── .audit-2                   # Output verification logs
 │   └── 📁 telemetry-stream/        # Real-time monitoring
 ├── ⚖️ rift-gov/                    # Governance & Policy
-│   ├── .riftrc.0 ... .riftrc.6    # Stage governance contracts
-│   ├── cost_thresholds.json       # Sinphasé configuration
-│   └── policy_validation.sh       # Compliance automation
+│   ├── accessibility_error_header.txt  # Header notes
+│   ├── accessibility_error_system.txt  # Implementation details
+│   ├── cmake_utility_modules.txt       # CMake modules
+│   ├── rift-dir-to-fix-clutterd.txt    # Cleanup notes
+│   ├── rift_consolidated_setup.sh      # Setup helper
+│   └── policy_validation.sh            # Compliance automation
 ├── 📊 rift-telemetry/              # Cryptographic Tracking
 │   ├── 📁 prng_generators/         # Secure randomization
 │   ├── 📁 uuid_tracking/           # Identifier management

--- a/rift-gov/policy_validation.sh
+++ b/rift-gov/policy_validation.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# policy_validation.sh
+# Validate RIFT governance policies across project stages.
+
+set -euo pipefail
+
+usage() {
+    echo "Usage: $0 [--stage=<stage>|--stage=all]" >&2
+    exit 1
+}
+
+STAGE="all"
+for arg in "$@"; do
+    case "$arg" in
+        --stage=*)
+            STAGE="${arg#*=}"
+            ;;
+        -h|--help)
+            usage
+            ;;
+        *)
+            echo "Unknown argument: $arg" >&2
+            usage
+            ;;
+    esac
+done
+
+echo "Validating governance policies for stage: $STAGE"
+# Placeholder validation logic
+# In a full implementation, this script would check policy files
+# and configuration settings for compliance.
+
+echo "Policy validation completed successfully."


### PR DESCRIPTION
## Summary
- add `policy_validation.sh` placeholder in `rift-gov/`
- update both directory diagrams in README
- ensure instructions point to an existing script

## Testing
- `make test` *(fails: missing separator in Makefile)*
- `./rift-gov/policy_validation.sh --stage=all`

------
https://chatgpt.com/codex/tasks/task_e_685c8ae5110c8327aab0197d26f73122