### PR TITLE
Make project index use relative paths

### DIFF
--- a/rift-core/setup/rift_project_index.txt
+++ b/rift-core/setup/rift_project_index.txt
@@ -1,0 +1,24 @@
+# RIFT Project File Index
+# Generated: Wed Jun 25 23:53:13 UTC 2025
+# Version: 0.1.0-alpha
+
+## C Source Files
+rift-core/src/common/core.c
+rift-core/src/thread/lifecycle.c
+rift-core/tests/unit/test_core.c
+
+## Header Files
+rift-core/include/rift-core/audit/tracer.h
+rift-core/include/rift-core/core.h
+rift-core/include/rift-core/thread/lifecycle.h
+
+## CMake Files
+CMakeLists.txt
+rift-core/CMakeLists.txt
+rift-core/tests/CMakeLists.txt
+
+## Configuration Files
+rift-core/config/governance.json
+
+## Documentation Files
+rift-core/README.md

--- a/rift-core/setup/setup-rift-core.sh
+++ b/rift-core/setup/setup-rift-core.sh
@@ -570,26 +570,26 @@ index_project_files() {
         echo ""
         
         echo "## C Source Files"
-        find "${ROOT_DIR}" -name "*.c" -type f | sort
+        find "${ROOT_DIR}" -name "*.c" -type f -exec realpath --relative-to="${ROOT_DIR}" {} \; | sort
         echo ""
         
         echo "## Header Files"
-        find "${ROOT_DIR}" -name "*.h" -type f | sort
+        find "${ROOT_DIR}" -name "*.h" -type f -exec realpath --relative-to="${ROOT_DIR}" {} \; | sort
         echo ""
         
         echo "## CMake Files"
-        find "${ROOT_DIR}" -name "CMakeLists.txt" -type f | sort
-        find "${ROOT_DIR}" -name "*.cmake" -type f | sort
+        find "${ROOT_DIR}" -name "CMakeLists.txt" -type f -exec realpath --relative-to="${ROOT_DIR}" {} \; | sort
+        find "${ROOT_DIR}" -name "*.cmake" -type f -exec realpath --relative-to="${ROOT_DIR}" {} \; | sort
         echo ""
         
         echo "## Configuration Files"
-        find "${ROOT_DIR}" -name "*.pc.in" -type f | sort
-        find "${ROOT_DIR}" -name "*.json" -type f | sort
+        find "${ROOT_DIR}" -name "*.pc.in" -type f -exec realpath --relative-to="${ROOT_DIR}" {} \; | sort
+        find "${ROOT_DIR}" -name "*.json" -type f -exec realpath --relative-to="${ROOT_DIR}" {} \; | sort
         echo ""
         
         echo "## Documentation Files"
-        find "${ROOT_DIR}" -name "*.md" -type f | sort
-        find "${ROOT_DIR}" -name "*.pdf" -type f | sort
+        find "${ROOT_DIR}" -name "*.md" -type f -exec realpath --relative-to="${ROOT_DIR}" {} \; | sort
+        find "${ROOT_DIR}" -name "*.pdf" -type f -exec realpath --relative-to="${ROOT_DIR}" {} \; | sort
         
     } > "${index_file}"
     
@@ -603,17 +603,20 @@ index_project_files() {
         echo "  \"files\": {"
         
         echo "    \"c_sources\": ["
-        find "${ROOT_DIR}" -name "*.c" -type f -printf '      "%p",' | sed '$s/,$//'
+        find "${ROOT_DIR}" -name "*.c" -type f -exec realpath --relative-to="${ROOT_DIR}" {} \; \
+            | sort | sed 's/^/      "&",/' | sed '$s/,$//' 
         echo ""
         echo "    ],"
         
         echo "    \"headers\": ["
-        find "${ROOT_DIR}" -name "*.h" -type f -printf '      "%p",' | sed '$s/,$//'
+        find "${ROOT_DIR}" -name "*.h" -type f -exec realpath --relative-to="${ROOT_DIR}" {} \; \
+            | sort | sed 's/^/      "&",/' | sed '$s/,$//' 
         echo ""
         echo "    ],"
         
         echo "    \"cmake_files\": ["
-        find "${ROOT_DIR}" -name "CMakeLists.txt" -o -name "*.cmake" -type f -printf '      "%p",' | sed '$s/,$//'
+        find "${ROOT_DIR}" \( -name "CMakeLists.txt" -o -name "*.cmake" \) -type f -exec realpath --relative-to="${ROOT_DIR}" {} \; \
+            | sort | sed 's/^/      "&",/' | sed '$s/,$//' 
         echo ""
         echo "    ]"
         


### PR DESCRIPTION
## Summary
- modify setup-rift-core script to index files relative to ROOT_DIR using `realpath`
- regenerate `rift_project_index.txt` with relative paths

## Testing
- `bash rift-core/setup/setup-rift-core.sh`

------
https://chatgpt.com/codex/tasks/task_e_685c8ae69bd083278d85e43a5d72509e