### PR TITLE
Implement aligned memory utilities

### DIFF
--- a/src/core/memory.c
+++ b/src/core/memory.c
@@ -1,0 +1,68 @@
+#include "rift/core/common.h"
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+
+#ifdef _POSIX_VERSION
+#include <errno.h>
+#endif
+
+void* rift_aligned_alloc(size_t size, size_t alignment) {
+#ifdef _POSIX_VERSION
+    void* ptr = NULL;
+    if (posix_memalign(&ptr, alignment, size) != 0) {
+        return NULL;
+    }
+    return ptr;
+#else
+    if (alignment < sizeof(void*))
+        alignment = sizeof(void*);
+    uintptr_t mask = (uintptr_t)alignment - 1;
+    void* raw = malloc(size + alignment - 1 + sizeof(void*));
+    if (!raw)
+        return NULL;
+    uintptr_t raw_addr = (uintptr_t)raw + sizeof(void*);
+    uintptr_t aligned_addr = (raw_addr + mask) & ~mask;
+    ((void**)aligned_addr)[-1] = raw;
+    return (void*)aligned_addr;
+#endif
+}
+
+void rift_aligned_free(void* ptr) {
+    if (!ptr)
+        return;
+#ifdef _POSIX_VERSION
+    free(ptr);
+#else
+    free(((void**)ptr)[-1]);
+#endif
+}
+
+void rift_memory_block_init(rift_memory_block_t* block, void* ptr,
+                            size_t size, size_t alignment,
+                            const char* allocator_name) {
+    if (!block)
+        return;
+    block->ptr = ptr;
+    block->size = size;
+    block->alignment = alignment;
+    block->is_aligned = ptr ? (((uintptr_t)ptr % alignment) == 0) : false;
+    block->allocator_name = allocator_name;
+}
+
+void rift_memory_block_cleanup(rift_memory_block_t* block) {
+    if (!block)
+        return;
+    block->ptr = NULL;
+    block->size = 0;
+    block->alignment = 0;
+    block->is_aligned = false;
+    block->allocator_name = NULL;
+}
+
+#ifndef aligned_alloc
+void* aligned_alloc(size_t alignment, size_t size) {
+    return rift_aligned_alloc(size, alignment);
+}
+#endif
+

--- a/tests/unit/core/test_memory_alignment.c
+++ b/tests/unit/core/test_memory_alignment.c
@@ -1,0 +1,53 @@
+#include "rift/core/common.h"
+#include <stdio.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <stdint.h>
+
+#define TEST_ASSERT(cond, msg) do { \
+    if (!(cond)) { \
+        printf("FAIL: %s\n", msg); \
+        printf("  Assertion failed: %s\n", #cond); \
+        printf("  File: %s, Line: %d\n", __FILE__, __LINE__); \
+        return false; \
+    } \
+} while(0)
+
+#define TEST_PASS(msg) do { \
+    printf("PASS: %s\n", msg); \
+    return true; \
+} while(0)
+
+static bool test_alignment_values(void) {
+    size_t alignments[] = {8, 16, 64, 4096};
+    for (size_t i = 0; i < sizeof(alignments)/sizeof(alignments[0]); ++i) {
+        size_t al = alignments[i];
+        void* ptr = rift_aligned_alloc(128, al);
+        TEST_ASSERT(ptr != NULL, "Allocation failed");
+        TEST_ASSERT(((uintptr_t)ptr % al) == 0, "Pointer not aligned");
+        rift_aligned_free(ptr);
+    }
+    TEST_PASS("Aligned allocations meet requirements");
+}
+
+static bool test_fallback_aligned_alloc(void) {
+    void* ptr = aligned_alloc(32, 128);
+    TEST_ASSERT(ptr != NULL, "aligned_alloc failed");
+    TEST_ASSERT(((uintptr_t)ptr % 32) == 0, "aligned_alloc pointer misaligned");
+#ifdef _POSIX_VERSION
+    free(ptr);
+#else
+    rift_aligned_free(ptr);
+#endif
+    TEST_PASS("aligned_alloc wrapper works");
+}
+
+int main(void) {
+    int tests_run = 0, tests_passed = 0;
+    printf("Memory Alignment Tests\n");
+    if (test_alignment_values()) tests_passed++; tests_run++;
+    if (test_fallback_aligned_alloc()) tests_passed++; tests_run++;
+    printf("%d/%d tests passed\n", tests_passed, tests_run);
+    return (tests_passed == tests_run) ? 0 : 1;
+}
+


### PR DESCRIPTION
## Summary
- implement `rift_aligned_alloc`, `rift_aligned_free`, and block helpers
- provide fallback `aligned_alloc` when C11 version isn't available
- add unit tests ensuring allocations respect alignment

## Testing
- `gcc -std=c11 -Iinclude tests/unit/core/test_memory_alignment.c src/core/memory.c -o /tmp/test_memory_alignment && /tmp/test_memory_alignment`


------
https://chatgpt.com/codex/tasks/task_e_685c8ae62a9083278bb52a7f247f7261