### PR TITLE
Add regex lifecycle header

### DIFF
--- a/include/rift/core/regex.h
+++ b/include/rift/core/regex.h
@@ -1,0 +1,68 @@
+/*
+ * rift/include/rift/core/regex.h
+ * RIFT Regular Expression Lifecycle Management Interface
+ * OBINexus Computing Framework - AEGIS Methodology
+ * Technical Lead: Nnamdi Michael Okpala
+ */
+
+#ifndef RIFT_CORE_REGEX_H
+#define RIFT_CORE_REGEX_H
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Regular expression lifecycle states */
+typedef enum rift_regex_lifecycle_state {
+    R_NIL_START     = 0x00,
+    R_EMPTY_START   = 0x01,
+    R_PATTERN_INIT  = 0x02,
+    R_COMPILE_PHASE = 0x03,
+    R_VALIDATE_PHASE= 0x04,
+    R_OPTIMIZE_PHASE= 0x05,
+    R_READY_STATE   = 0x06,
+    R_EXECUTE_PHASE = 0x07,
+    R_MATCH_SUCCESS = 0x08,
+    R_MATCH_FAILURE = 0x09,
+    R_ERROR_STATE   = 0x0A,
+    R_CLEANUP_PHASE = 0x0B,
+    R_END_STATE     = 0x0C,
+    R_EOF           = 0xFF
+} rift_regex_lifecycle_t;
+
+/* Chomsky hierarchy classification */
+typedef enum rift_chomsky_type {
+    CHOMSKY_TYPE_3 = 3,
+    CHOMSKY_TYPE_2 = 2,
+    CHOMSKY_TYPE_1 = 1,
+    CHOMSKY_TYPE_0 = 0
+} rift_chomsky_type_t;
+
+/* Regular expression pattern structure */
+typedef struct rift_regex_pattern {
+    rift_chomsky_type_t     chomsky_type;
+    rift_regex_lifecycle_t  lifecycle_state;
+    const char*             pattern_string;
+    uint32_t                flags;
+    uint64_t                pattern_hash;
+    void*                   automaton_state;
+} rift_regex_pattern_t;
+
+/* flag definitions */
+#define RIFT_REGEX_GLOBAL       0x01
+#define RIFT_REGEX_MULTILINE    0x02
+#define RIFT_REGEX_IGNORECASE   0x04
+#define RIFT_REGEX_TAINTED      0x80
+
+/* parse standard flag strings like "gmi" */
+uint32_t rift_regex_parse_flags(const char* flag_string);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* RIFT_CORE_REGEX_H */

--- a/src/core/regex.c
+++ b/src/core/regex.c
@@ -1,0 +1,33 @@
+/*
+ * rift/src/core/regex.c
+ * Simple flag parsing utility for RIFT regex patterns
+ */
+
+#include "rift/core/regex.h"
+
+uint32_t rift_regex_parse_flags(const char* flag_string) {
+    if (!flag_string) {
+        return 0;
+    }
+
+    uint32_t flags = 0;
+    for (const char* p = flag_string; *p; ++p) {
+        switch (*p) {
+            case 'g':
+                flags |= RIFT_REGEX_GLOBAL;
+                break;
+            case 'm':
+                flags |= RIFT_REGEX_MULTILINE;
+                break;
+            case 'i':
+                flags |= RIFT_REGEX_IGNORECASE;
+                break;
+            case 't':
+                flags |= RIFT_REGEX_TAINTED;
+                break;
+            default:
+                break;
+        }
+    }
+    return flags;
+}


### PR DESCRIPTION
## Summary
- add regex lifecycle management header
- implement flag parsing helper

## Testing
- `make -j$(nproc) all` *(fails: generate_hash_table.sh: bc: command not found)*
- `make test` *(fails: No rule to make target 'test')*
- `./tools/qa_framework.sh --comprehensive` *(fails: Beta testing failed for stage 0)*

------
https://chatgpt.com/codex/tasks/task_e_685de282a4dc832790f68e1e3e41fb64