### PR TITLE
Add minimal Python tokenizer for RIFT

### DIFF
--- a/riftlib/tokenizer.py
+++ b/riftlib/tokenizer.py
@@ -1,0 +1,62 @@
+"""RIFT Stage 0 Tokenizer
+
+This module provides a very small tokenizer based on the RIFT Stage 0
+specification. It exposes a :func:`tokenize` function that converts source
+strings into a sequence of tokens. The rules are taken from the language
+specification and use Python regular expressions for matching.
+"""
+
+from dataclasses import dataclass
+import re
+from typing import List, Tuple
+
+
+@dataclass
+class Token:
+    """Simple token data structure."""
+
+    type: str
+    value: str
+    start: int
+    end: int
+
+
+class Tokenizer:
+    """Compile regular expressions and tokenize RIFT source code."""
+
+    def __init__(self) -> None:
+        # Order matters: governance and memory references should be matched
+        # before generic identifiers to avoid premature matches.
+        patterns = [
+            ("GOVERNANCE", r"governance\s*\{[^}]*\}"),
+            ("MEMORY_REF", r"@[a-zA-Z_][a-zA-Z0-9_]*"),
+            ("FUNC_SIG", r"\w+\s*\([^)]*\)"),
+            ("EXPR_BLOCK", r"\{[^}]*\}"),
+            ("STRING", r"\"([^\"\\]|\\.)*\""),
+            ("NUMBER", r"\d+(\.\d+)?([eE][+-]?\d+)?"),
+            ("IDENTIFIER", r"[a-zA-Z_][a-zA-Z0-9_]*"),
+        ]
+        self.regex = re.compile(
+            "|".join(f"(?P<{name}>{pattern})" for name, pattern in patterns)
+        )
+
+    def tokenize(self, text: str) -> List[Token]:
+        tokens: List[Token] = []
+        pos = 0
+        while pos < len(text):
+            match = self.regex.match(text, pos)
+            if not match:
+                # Skip unknown character
+                pos += 1
+                continue
+            typ = match.lastgroup
+            value = match.group(typ)
+            tokens.append(Token(typ, value, match.start(), match.end()))
+            pos = match.end()
+        return tokens
+
+
+def tokenize(text: str) -> List[Token]:
+    """Tokenize a text string using the default tokenizer."""
+
+    return Tokenizer().tokenize(text)

--- a/tests/python/test_tokenizer.py
+++ b/tests/python/test_tokenizer.py
@@ -1,0 +1,23 @@
+import unittest
+from riftlib.tokenizer import tokenize
+
+
+class TokenizerTest(unittest.TestCase):
+    def test_basic_tokenization(self):
+        source = (
+            'governance { stage: 0 }\n'
+            'function foo(bar) { return bar + 42 }\n'
+            '@memory1\n'
+            '"hello" 123'
+        )
+        tokens = tokenize(source)
+        self.assertTrue(any(t.type == 'GOVERNANCE' for t in tokens))
+        self.assertTrue(any(t.type == 'FUNC_SIG' for t in tokens))
+        self.assertTrue(any(t.type == 'MEMORY_REF' for t in tokens))
+        self.assertTrue(any(t.type == 'STRING' for t in tokens))
+        self.assertTrue(any(t.type == 'NUMBER' for t in tokens))
+
+
+if __name__ == '__main__':
+    for token in tokenize('governance { a }'):
+        print(token)


### PR DESCRIPTION
## Summary
- implement a simple Stage 0 tokenizer in `riftlib`
- document the interface via docstrings
- add a unittest that exercises the tokenizer

## Testing
- `python3 -m unittest tests/python/test_tokenizer.py`

------
https://chatgpt.com/codex/tasks/task_e_685e92fdaa848327a2d9eb26efeb168b