### PR TITLE
Add Sinphase governance cost module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/rift-core/include)
 
 # Add RIFT-Core subdirectory
 add_subdirectory(rift-core)
+add_subdirectory(governance)
 
 # Add RIFT stages in dependency order
 add_subdirectory(rift-0)

--- a/governance/CMakeLists.txt
+++ b/governance/CMakeLists.txt
@@ -1,0 +1,16 @@
+add_library(rift-sinphase STATIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/governance/sinphase.c
+)
+
+target_include_directories(rift-sinphase PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
+)
+
+set_target_properties(rift-sinphase PROPERTIES
+    VERSION ${PROJECT_VERSION}
+)
+
+install(TARGETS rift-sinphase
+    ARCHIVE DESTINATION lib
+    PUBLIC_HEADER DESTINATION include/rift/governance
+)

--- a/include/rift/governance/sinphase.h
+++ b/include/rift/governance/sinphase.h
@@ -1,0 +1,43 @@
+#ifndef RIFT_GOVERNANCE_SINPHASE_H
+#define RIFT_GOVERNANCE_SINPHASE_H
+
+#include <stddef.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Phase state enumeration for Sinphase governance */
+typedef enum {
+    RIFT_PHASE_RESEARCH,
+    RIFT_PHASE_IMPLEMENTATION,
+    RIFT_PHASE_VALIDATION,
+    RIFT_PHASE_ISOLATION
+} rift_phase_state_t;
+
+/* Component metrics used in cost calculation */
+typedef struct {
+    size_t include_depth;
+    size_t function_calls;
+    size_t external_deps;
+    size_t complexity;
+    size_t link_deps;
+    size_t circular_deps;
+    float temporal_pressure;
+} rift_component_metrics_t;
+
+/* Cost evaluation result */
+float rift_sinphase_compute_cost(const rift_component_metrics_t *metrics,
+                                 const float weights[5]);
+
+static inline bool rift_sinphase_exceeds_threshold(float cost, float threshold)
+{
+    return cost > threshold;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* RIFT_GOVERNANCE_SINPHASE_H */

--- a/src/governance/sinphase.c
+++ b/src/governance/sinphase.c
@@ -1,0 +1,24 @@
+#include "rift/governance/sinphase.h"
+
+float rift_sinphase_compute_cost(const rift_component_metrics_t *metrics,
+                                 const float weights[5])
+{
+    if (!metrics || !weights) {
+        return 0.0f;
+    }
+
+    float cost = 0.0f;
+    cost += (float)metrics->include_depth   * weights[0];
+    cost += (float)metrics->function_calls  * weights[1];
+    cost += (float)metrics->external_deps   * weights[2];
+    cost += (float)metrics->complexity      * weights[3];
+    cost += (float)metrics->link_deps       * weights[4];
+
+    /* Circular dependency penalty */
+    cost += (float)metrics->circular_deps * 0.2f;
+
+    /* Temporal pressure directly increases cost */
+    cost += metrics->temporal_pressure;
+
+    return cost;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,3 +1,5 @@
 # Tests placeholder
 enable_testing()
 message(STATUS "Test framework initialized")
+
+add_subdirectory(governance)

--- a/tests/governance/CMakeLists.txt
+++ b/tests/governance/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_executable(test_sinphase test_sinphase.c)
+
+target_link_libraries(test_sinphase PRIVATE rift-sinphase)
+
+target_include_directories(test_sinphase PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+)
+
+add_test(NAME SinphaseTest COMMAND test_sinphase)

--- a/tests/governance/test_sinphase.c
+++ b/tests/governance/test_sinphase.c
@@ -1,0 +1,25 @@
+#include "rift/governance/sinphase.h"
+#include <stdio.h>
+#include <assert.h>
+
+int main(void)
+{
+    rift_component_metrics_t metrics = {1, 2, 0, 3, 1, 1, 0.1f};
+    float weights[5] = {0.1f, 0.1f, 0.1f, 0.1f, 0.1f};
+
+    float cost = rift_sinphase_compute_cost(&metrics, weights);
+    /* Expected cost = sum(metrics * 0.1) + 0.2*circular + temporal*/
+    float expected = (1+2+0+3+1)*0.1f + 1*0.2f + 0.1f;
+    if (cost < expected - 1e-6 || cost > expected + 1e-6) {
+        printf("Cost mismatch: expected %f, got %f\n", expected, cost);
+        return 1;
+    }
+
+    if (!rift_sinphase_exceeds_threshold(cost, 0.5f)) {
+        printf("Threshold evaluation failed\n");
+        return 1;
+    }
+
+    printf("All Sinphase tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- implement Sinphase governance cost evaluation
- compile as new `rift-sinphase` static library
- add unit test for Sinphase cost computation

## Testing
- `cmake ..` *(fails: Target OBJECT library error)*

------
https://chatgpt.com/codex/tasks/task_e_685c7e21d4dc832798181d988866e884